### PR TITLE
Adding vim.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.vim?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=142&branchName=master)
+
+# vim
+
+Vim is a greatly improved version of the good old UNIX editor Vi
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "vim"

--- a/controls/vim_test.rb
+++ b/controls/vim_test.rb
@@ -1,0 +1,45 @@
+title 'Tests to confirm vim works as expected'
+
+plan_name = input('plan_name', value: 'vim')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-vim' do
+  impact 1.0
+  title 'Ensure vim works'
+  desc '
+  For vim we check that the --version and --help commands work and are correct e.g.
+
+    $ vim --version
+    VIM - Vi IMproved 8.1 (2018 May 18, compiled Dec 13 2019 14:45:40)
+    Included patches: 1-503, 505-680, 682-1312
+    ...
+
+    $ vim --help
+    VIM - Vi IMproved 8.1 (2018 May 18, compiled Dec 13 2019 14:45:40)
+
+    Usage: vim [arguments] [file ..]       edit specified file(s)
+       or: vim [arguments] -               read text from stdin
+    ...
+  '
+  vim_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe vim_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  vim_pkg_ident = vim_pkg_ident.stdout.strip
+
+  describe command("#{vim_pkg_ident}/bin/vim --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Compiled by Habitat, vim release #{vim_pkg_ident.split('/')[5]}/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{vim_pkg_ident}/bin/vim --help") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /VIM - Vi IMproved/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: vim
+title: Habitat Core Plan vim
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan vim
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,80 @@
+pkg_name=vim
+pkg_origin=core
+pkg_version=8.1.1694
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Vim is a highly configurable text editor built to make creating and changing \
+any kind of text very efficient. It is included as "vi" with most UNIX \
+systems and with Apple OS X.\
+"
+pkg_upstream_url="http://www.vim.org/"
+pkg_license=("Vim")
+pkg_source="http://github.com/${pkg_name}/${pkg_name}/archive/v${pkg_version}.tar.gz"
+pkg_shasum="51dc24a7954cc9f8d75be02870ce32dcd7185139688f998b27d135e34de57ca4"
+pkg_deps=(
+  core/acl
+  core/attr
+  core/glibc
+  core/ncurses
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+  core/autoconf
+)
+pkg_bin_dirs=(bin)
+
+do_prepare() {
+  pushd src > /dev/null
+    autoconf
+  popd > /dev/null
+
+  export CPPFLAGS="$CPPFLAGS $CFLAGS -O2"
+  build_line "Setting CPPFLAGS=$CPPFLAGS"
+}
+
+do_build() {
+  ./configure \
+    --prefix="${pkg_prefix}" \
+    --with-compiledby="Habitat, vim release ${pkg_version}" \
+    --with-features=huge \
+    --enable-acl \
+    --with-x=no \
+    --disable-gui \
+    --enable-multibyte
+  make
+}
+
+do_install() {
+  do_default_install
+
+  # Add a `vi` which symlinks to `vim`
+  ln -sv vim "${pkg_prefix}/bin/vi"
+
+  # Install license file
+  install -Dm644 runtime/doc/uganda.txt "${pkg_prefix}/share/licenses/license.txt"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/sed
+    core/diffutils
+    core/make
+    core/patch
+    core/autoconf
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} vim --version | head -n3 | tail -n1)"
+  [ "$result" = "Compiled by Habitat, vim release ${TEST_PKG_VERSION}" ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Migration of vim from core plans plus inspec tests:

```
Profile: Habitat Core Plan vim (vim)
Version: 0.1.0
Target:  docker://599f44ab76bb7a7d23be405a83ad02da941caf2c222e58dfdd512e320c419d8e

  ✔  core-plans-vim: Ensure vim works
     ✔  Command: `hab pkg path habskp/vim` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/vim` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/vim/8.1.1694/20200612110416/bin/vim --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/vim/8.1.1694/20200612110416/bin/vim --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/vim/8.1.1694/20200612110416/bin/vim --version` stdout is expected to match /Compiled by Habitat, vim release 8.1.1694/
     ✔  Command: `/hab/pkgs/habskp/vim/8.1.1694/20200612110416/bin/vim --version` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/vim/8.1.1694/20200612110416/bin/vim --help` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/vim/8.1.1694/20200612110416/bin/vim --help` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/vim/8.1.1694/20200612110416/bin/vim --help` stdout is expected to match /VIM - Vi IMproved/
     ✔  Command: `/hab/pkgs/habskp/vim/8.1.1694/20200612110416/bin/vim --help` stderr is expected to be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 10 successful, 0 failures, 0 skipped
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
